### PR TITLE
docs: add Lindell 17 security-with-abort notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The library implements three different mpc protocols for threshold ECDSA now.
     - Sign: Generates an ECDSA signature for specified message.
 - Lindell17[\[7\]](#Reference): A classical two-party ECDSA protocol originates from Lindell ’17 [\[7\]](#Reference). It is a threshold ECDSA signature scheme specifically designed for two-party computation (2PC) scenarios.
   This release is a variant of Lindell 17 protocol based on the additive secret sharing, please consult the following "Important Tips" section for the specific differences on protocol.
+  ⚠️ It follows the "security with abort" model and requires abort monitoring on the integrator side; see [SECURITY_NOTICE.md](./src/multi-party-sig/two-party-ecdsa/lindell17/SECURITY_NOTICE.md) before integrating.
     - Key Generation:  Generate the private key shard for Party 1 and Party 2 respectively.
     - Sign: Generates an ECDSA signature for specified message.
 
@@ -426,6 +427,8 @@ At the end of the MPC Procedure, each signer will get the secret share which cou
 Refer to the [test case](./test/cmp/sign_t_n_mt_test.cpp) for more details.
 
 ## Lindell 17
+
+> ⚠️ **Security Notice:** this implementation follows the "security with abort" model and requires abort monitoring on the integrator side. Read [SECURITY_NOTICE.md](./src/multi-party-sig/two-party-ecdsa/lindell17/SECURITY_NOTICE.md) before integrating.
 
 ### Key Generation
 

--- a/src/multi-party-sig/two-party-ecdsa/lindell17/SECURITY_NOTICE.md
+++ b/src/multi-party-sig/two-party-ecdsa/lindell17/SECURITY_NOTICE.md
@@ -1,0 +1,25 @@
+# Security Notice — Lindell 17
+
+This implementation follows the **"security with abort"** model of the original
+Lindell 17 protocol ([eprint 2017/552](https://eprint.iacr.org/2017/552.pdf)).
+This is a deliberate design tradeoff of the protocol, not a defect of this
+implementation. Under this model a corrupted party may abort after learning
+information that the honest party does not. Integrators are therefore
+responsible for the deployment safeguards below.
+
+## Deployment Responsibility
+
+When you integrate this protocol, you **must**:
+
+1. **Monitor for aborts.** In an honest run the signing flow always verifies
+   successfully. Therefore any single failure — `Step3` returning `false` — is
+   conclusive evidence that the counterparty is behaving maliciously.
+
+2. **Stop and migrate on the first abort.** On any such failure, immediately
+   stop using the affected key pair and migrate the associated assets to a new
+   wallet. Do not retry signing with the same key share.
+
+Without this monitoring, a malicious counterparty can repeatedly query the
+signing flow and use the abort responses as an oracle to recover the honest
+party's private key share. Cutting the session off at the first abort breaks
+this attack.


### PR DESCRIPTION
Document the integrator's deployment responsibility for the Lindell 17 "security with abort" model: monitor for aborts (any Step3 returning false indicates a malicious counterparty) and, on the first abort, immediately stop using the key pair and migrate the assets.

- Add SECURITY_NOTICE.md in the lindell17 implementation directory.
- Add warnings in the README protocol overview and the Lindell 17 section.